### PR TITLE
Fixed a runtime error in the advanced example

### DIFF
--- a/advanced.ts
+++ b/advanced.ts
@@ -53,7 +53,7 @@ let activeCursor = ""
 
 apolloClient.subscribe({
   query: gql`
-    subscription(cursor: String!) {
+    subscription($cursor: String!) {
       searchTransactionsForward(query: "status:executed", cursor: $cursor) {
         cursor
         trace { matchingActions {receiver account name json }}


### PR DESCRIPTION
When running the advanced example, I'm getting this error:
```
GraphQLError: Syntax Error: Expected $, found Name "cursor"
```

The `$` is missing in the variable declaration.